### PR TITLE
Add CappedBackoff and JitterBackoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ implicit val retryPolicy = retryForever using selectedBackoff {
 }
 ```
 
-Finally, any backoff policy can be configured so that each successive backoff duration is perturbed by a random value:
+Any backoff policy can be configured so that each successive backoff duration is perturbed by a random value:
 
 ```scala
 import scala.concurrent.duration._
@@ -273,6 +273,25 @@ implicit val retryPolicy = retryForever using { constantBackoff { 1 second } ran
 
 // Randomizes each backoff duration by adding a random duration between -30 seconds and 30 seconds.
 val otherRetryPolicy = retryForever using { linearBackoff { 5 minutes } randomized -30.seconds -> 30.seconds }
+```
+
+Backoff policies can be capped at a maximal value:
+
+```scala
+import scala.concurrent.duration._
+import atmos.dsl._
+
+// Waits 4 minutes, 8 minutes, then 10 minutes, 10 minutes, 10 minutes ... 
+val policy = retryForever using { exponentialBackoff { 4.minutes } capped 10.minutes }
+```
+
+Finally, backoff policies can have random jitter applied:
+```scala
+import scala.concurrent.duration._
+import atmos.dsl._
+
+// Waits some random time between 0 and 4 minutes, 8 minutes, 16 minutes ...
+val policy = retryForever using { exponentialBackoff { 4.minutes } withJitter }
 ```
 
 <a name="event-monitors"></a>

--- a/src/main/scala/atmos/backoff/CappedBackoff.scala
+++ b/src/main/scala/atmos/backoff/CappedBackoff.scala
@@ -1,0 +1,20 @@
+package atmos.backoff
+
+import atmos.BackoffPolicy
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+
+
+/**
+  * A policy that uses the minimum of either the cap or the result of the base policy.
+  *
+  * @param policy The base policy to be capped
+  * @param cap    The maximum backoff
+  */
+case class CappedBackoff(policy: BackoffPolicy, cap: FiniteDuration) extends BackoffPolicy {
+  override def nextBackoff(attempts: Int, outcome: Try[Any]) = {
+    val next = policy.nextBackoff(attempts, outcome)
+    if (next > cap) cap else next
+  }
+}

--- a/src/main/scala/atmos/backoff/CappedBackoff.scala
+++ b/src/main/scala/atmos/backoff/CappedBackoff.scala
@@ -5,7 +5,6 @@ import atmos.BackoffPolicy
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
-
 /**
   * A policy that uses the minimum of either the cap or the result of the base policy.
   *

--- a/src/main/scala/atmos/backoff/ConstantBackoff.scala
+++ b/src/main/scala/atmos/backoff/ConstantBackoff.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 /**
  * A policy that uses the same backoff after every retry.
  *
- * @param initialBackoff The backoff used for every retry.
+ * @param backoff The backoff used for every retry.
  */
 case class ConstantBackoff(backoff: FiniteDuration = defaultBackoff) extends atmos.BackoffPolicy {
 

--- a/src/main/scala/atmos/backoff/JitterBackoff.scala
+++ b/src/main/scala/atmos/backoff/JitterBackoff.scala
@@ -1,0 +1,17 @@
+package atmos.backoff
+
+import atmos.BackoffPolicy
+
+import scala.concurrent.duration._
+import scala.util.{Random, Try}
+
+/**
+  * A policy that randomly spreads backoff attempts over the range provided by another policy
+  *
+  * @param policy The base policy to which jitter should be applied
+  */
+case class JitterBackoff(policy: BackoffPolicy) extends BackoffPolicy {
+  override def nextBackoff(attempts: Int, outcome: Try[Any]) = {
+    (policy.nextBackoff(attempts, outcome).toNanos * Random.nextDouble()).toLong.nanos
+  }
+}

--- a/src/main/scala/atmos/dsl/BackoffPolicyExtensions.scala
+++ b/src/main/scala/atmos/dsl/BackoffPolicyExtensions.scala
@@ -42,4 +42,15 @@ case class BackoffPolicyExtensions(self: BackoffPolicy) extends AnyVal {
    */
   def randomized(range: (FiniteDuration, FiniteDuration)): BackoffPolicy = backoff.RandomizedBackoff(self, range)
 
+  /**
+   * Creates a backoff policy that caps the result of `self`.
+   *
+   * @param cap The maximum backoff to be returned by this policy
+   */
+  def capped(cap: FiniteDuration): BackoffPolicy = backoff.CappedBackoff(self, cap)
+
+  /**
+   * Creates a backoff policy that adds jitter to `self`.
+   */
+  def withJitter = backoff.JitterBackoff(self)
 }

--- a/src/main/scala/atmos/dsl/BackoffPolicyExtensions.scala
+++ b/src/main/scala/atmos/dsl/BackoffPolicyExtensions.scala
@@ -52,5 +52,5 @@ case class BackoffPolicyExtensions(self: BackoffPolicy) extends AnyVal {
   /**
    * Creates a backoff policy that adds jitter to `self`.
    */
-  def withJitter = backoff.JitterBackoff(self)
+  def withJitter: BackoffPolicy = backoff.JitterBackoff(self)
 }

--- a/src/test/scala/atmos/backoff/CappedBackoffSpec.scala
+++ b/src/test/scala/atmos/backoff/CappedBackoffSpec.scala
@@ -1,0 +1,25 @@
+package atmos.backoff
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+/**
+ * Test suite for [[atmos.backoff.CappedBackoff]].
+ */
+class CappedBackoffSpec extends FlatSpec with Matchers {
+
+  val result = "result"
+  val thrown = new RuntimeException
+
+  "CappedBackoff" should "cap the result of another backoff policy" in {
+    for {
+      backoff <- 1L to 100L map (100.millis * _)
+      cap <- Seq((0.5 * backoff.toNanos).nanos, backoff, (1.5 * backoff.toNanos).nanos)
+      policy = CappedBackoff(ConstantBackoff(backoff), cap)
+      outcome <- Seq(Success(result), Failure(thrown))
+      attempt <- 1 to 10
+    } policy.nextBackoff(attempt, outcome).toNanos should be <= cap.toNanos
+  }
+}

--- a/src/test/scala/atmos/backoff/JitterBackoffSpec.scala
+++ b/src/test/scala/atmos/backoff/JitterBackoffSpec.scala
@@ -1,0 +1,25 @@
+package atmos.backoff
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+/**
+  * Test suite for [[atmos.backoff.JitterBackoff]].
+  */
+class JitterBackoffSpec extends FlatSpec with Matchers {
+
+  val result = "result"
+  val thrown = new RuntimeException
+
+  "JitterBackoff" should "add jitter to the result of another backoff policy" in {
+    for {
+      backoff <- 1L to 100L map (100.millis * _)
+      base = ExponentialBackoff(backoff)
+      policy = JitterBackoff(base)
+      outcome <- Seq(Success(result), Failure(thrown))
+      attempt <- 1 to 10
+    } policy.nextBackoff(attempt, outcome).toNanos should be <= base.nextBackoff(attempt, outcome).toNanos
+  }
+}

--- a/src/test/scala/atmos/dsl/RetryDSLSpec.scala
+++ b/src/test/scala/atmos/dsl/RetryDSLSpec.scala
@@ -67,6 +67,9 @@ class RetryDSLSpec extends FlatSpec with Matchers with MockFactory {
     val max = 10.millis
     retrying using LinearBackoff().randomized(max) shouldEqual RetryPolicy(backoff = RandomizedBackoff(LinearBackoff(), zero -> max))
     retrying using LinearBackoff().randomized(min -> max) shouldEqual RetryPolicy(backoff = RandomizedBackoff(LinearBackoff(), min -> max))
+    val cap = 10.millis
+    retrying using LinearBackoff().capped(cap) shouldEqual RetryPolicy(backoff = CappedBackoff(LinearBackoff(), cap))
+    retrying using LinearBackoff().withJitter shouldEqual RetryPolicy(backoff = JitterBackoff(LinearBackoff()))
   }
 
   it should "configure retry policies with event monitors" in {


### PR DESCRIPTION
Adds two new backoff policies:
* `CappedBackoff` which restricts the backoff of a base backoff policy to some maximal value
* `JitterBackoff` which selects a random backoff value between zero and the result of a base backoff policy

Usage as described in the README:

```scala
import scala.concurrent.duration._
import atmos.dsl._

// capped: Waits 4 minutes, 8 minutes, then 10 minutes, 10 minutes, 10 minutes ... 
retryForever using { exponentialBackoff { 4.minutes } capped 10.minutes }

// jitter: Waits some random time between 0 and 4 minutes, 8 minutes, 16 minutes ...
retryForever using { exponentialBackoff { 4.minutes } withJitter }

// both
retryForever using { exponentialBackoff { 4.minutes } capped 10.minutes withJitter }
```

Both of these motivated by: [Exponential Backoff And Jitter](https://www.awsarchitectureblog.com/2015/03/backoff.html)